### PR TITLE
fix: request own user's comments, rather than deltabot's

### DIFF
--- a/delta-boards-three/index.js
+++ b/delta-boards-three/index.js
@@ -68,7 +68,7 @@ class DeltaBoardsThree {
         after,
       }
       const { api } = this
-      const commentJson = await api.query(`/user/deltabot/comments?${stringify(commentQuery)}`)
+      const commentJson = await api.query(`/user/${this.credentials.username}/comments?${stringify(commentQuery)}`)
       after = _.get(commentJson, 'data.after')
       if (!after) noMoreComments = true
 


### PR DESCRIPTION
Unless I'm missing something, testbots wouldn't want to read deltabot's inbox, right?  They should always read their own; for whoever runs deltabot itself, this would use the same username.