### PR TITLE
add additional debug information, and heavily verbose --debug/npm run start-debug modes

### DIFF
--- a/RedditAPIDriver/index.js
+++ b/RedditAPIDriver/index.js
@@ -8,9 +8,10 @@ import _ from 'lodash'
 fs.readFile = promisify(fs.readFile)
 
 module.exports = class RedditAPIDriver {
-  constructor(credentials, version, sessionPath) {
-    this.sessionPath = sessionPath || './'
+  constructor(credentials, version, sessionPath, flags) {
+    this.sessionPath = sessionPath
     this.credentials = credentials
+    this.flags = flags
     this.headers = {}
     this.baseURL = 'https://oauth.reddit.com'
     this.version = version
@@ -112,7 +113,10 @@ module.exports = class RedditAPIDriver {
             retry(res, rej)
           }
         } else if (statusCode === 401 || statusCode === 403) {
-          console.log('75 R_API')
+          console.log('75 R_API (status was 401 or 403)')
+          if (this.flags.isDebug) {
+            console.log(response)
+          }
           await this.connect({ type: 'GET_NEW_SESSION' })
           retry(res, rej)
         } else if (statusCode === 404) {

--- a/delta-boards-three/index.js
+++ b/delta-boards-three/index.js
@@ -5,9 +5,10 @@ import parseHiddenParams from './../parse-hidden-params'
 import getWikiContent from './../get-wiki-content'
 
 class DeltaBoardsThree {
-  constructor({ credentials, version }) {
+  constructor({ credentials, version, flags }) {
     this.credentials = credentials // this is used to log into the Reddit API
     this.version = version // this is used to mark the headers of the API calls
+    this.flags = flags // can be used to read the `isDebug` flag, used in RedditAPIDriver as well
   }
   // this method is called by DB3 main code. It starts
   // the whole process of updating the Delta Boards
@@ -16,7 +17,7 @@ class DeltaBoardsThree {
     const { credentials, version } = this
 
     // instantiate a new reddit API with the credentials and version
-    this.api = new Api(credentials, version, './delta-boards-three/')
+    this.api = new Api(credentials, version, './delta-boards-three/', this.flags)
 
     // make the api a variable so we don't access it from 'this' all the time
     const { api } = this

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "entry.js",
   "scripts": {
     "start": "supervisor -w entry.js,server.js,RedditAPIDriver,delta-boards-three entry",
+    "start-debug": "node ./entry.js --debug",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/server.js
+++ b/server.js
@@ -16,7 +16,12 @@ import i18n from './i18n'
 import parseHiddenParams from './parse-hidden-params'
 import getWikiContent from './get-wiki-content'
 
-console.log('server.js called!'.gray)
+const isDebug = _.some(process.argv, arg => {
+  return arg === '--debug'
+})
+if (isDebug) {
+  console.log('server.js called!  running in debug mode')
+}
 
 const last = []
 setInterval(() => {
@@ -60,7 +65,8 @@ const packageJson = require('./package.json')
 
 const subreddit = credentials.subreddit
 const botUsername = credentials.username
-const reddit = new Reddit(credentials, packageJson.version)
+const flags = { isDebug }
+const reddit = new Reddit(credentials, packageJson.version, './', flags)
 
 const getNewComments = async (recursiveList) => {
   console.log('Making comments call!')
@@ -216,7 +222,7 @@ const addOrRemoveDeltaToOrFromWiki = async ({
       }
       return hiddenParams
     } catch (err) {
-      console.log('216')
+      console.log('216 - failed to create wiki hidden params')
       console.log(err)
       return {
         comment: i18n[locale].hiddenParamsComment,
@@ -733,6 +739,7 @@ const entry = async () => {
     const deltaBoardsThree = new DeltaBoardsThree({
       credentials: deltaBoardsThreeCredentials,
       version: packageJson.version,
+      flags
     })
     deltaBoardsThree.initialStart()
   } catch (err) {


### PR DESCRIPTION
Take it or leave it, of course.  Running the server script, it wasn't clear to me what "75 R_API" in the console meant, and in general I think the premise of having a series of debug flags for running the deltabot script would be useful.  Perhaps the one condition currently guarded by an `ifDebug` check isn't all that useful (indeed, it didn't give me any new information apart from knowing that I got a 403 rather than a 401), but perhaps this change is worth merging anyway.