### PR TITLE
build: add & document `npm run test` command, for running eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Any contributions are much appreciated. Please keep your PRs to 1 commit and put
 1. get a Reddit API key by going to https://www.reddit.com/prefs/apps/ => create another app => https://i.imgur.com/xMUa521.png
 1. create a `credentials.json` that looks like below
 1. `npm start` and it should work
+1. Before submitting any pull request, ensure that `npm run test` passes with no errors
 
 #### credentials.json
 ````

--- a/RedditAPIDriver/index.js
+++ b/RedditAPIDriver/index.js
@@ -56,12 +56,12 @@ module.exports = class RedditAPIDriver {
   }
   async query(params, noOauth, wiki, count = 0) {
     const paramsReadable = _.isString(params) ? `GET ${params}` : `${params.method} ${params.URL}`
-    const debugInfo = this.flags.isDebug ? ` for request (${paramsReadable})` : '';
+    const debugInfo = this.flags.isDebug ? ` for request (${paramsReadable})` : ''
     try {
       return await new Promise(async (res, rej) => {
         let gotResponse
         const retry = (resRetry, rejRetry) => {
-          if (count >= 5) rejRetry(Error(`Something happened! There were 5 errors! R_API${debugInfo}`))
+          if (count >= 5) rejRetry(Error(`What happened? There were 5 errors - R_API${debugInfo}`))
           else {
             console.log(`Retrying in 10 seconds! R_API${debugInfo}`)
             setTimeout(async () => {

--- a/delta-boards-three/index.js
+++ b/delta-boards-three/index.js
@@ -31,9 +31,11 @@ class DeltaBoardsThree {
 
     // this method return a string that allows us to add metadata
     // to a listing without being seen by anybody other than DB3
+    /* eslint-disable no-irregular-whitespace */
     const stringifyObjectToBeHidden = input => (
       `[​](HTTP://DB3PARAMSSTART\n${JSON.stringify(input, null, 2)}\nDB3PARAMSEND)`
     )
+    /* eslint-enable no-irregular-whitespace */
 
     // get the date variables ready
     const now = new Date()
@@ -69,7 +71,9 @@ class DeltaBoardsThree {
         after,
       }
       const { api } = this
-      const commentJson = await api.query(`/user/${this.credentials.username}/comments?${stringify(commentQuery)}`)
+      const commentJson = await api.query(
+        `/user/${this.credentials.username}/comments?${stringify(commentQuery)}`
+      )
       after = _.get(commentJson, 'data.after')
       if (!after) noMoreComments = true
 
@@ -219,7 +223,8 @@ class DeltaBoardsThree {
       const { api } = this
 
       // grab the newHiddenParams from the wiki page
-      const deltaBoardsWikiContent = await getWikiContent({ api, subreddit, wikiPage: 'deltaboards' })
+      const wikiPage = 'deltaboards'
+      const deltaBoardsWikiContent = await getWikiContent({ api, subreddit, wikiPage })
       const oldHiddenParams = parseHiddenParams(deltaBoardsWikiContent)
 
       // if the monthly data has changed, update the sidebar

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "supervisor -w entry.js,server.js,RedditAPIDriver,delta-boards-three entry",
     "start-debug": "node ./entry.js --debug",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint ./RedditAPIDriver ./delta-boards-three server.js"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -16,9 +16,7 @@ import i18n from './i18n'
 import parseHiddenParams from './parse-hidden-params'
 import getWikiContent from './get-wiki-content'
 
-const isDebug = _.some(process.argv, arg => {
-  return arg === '--debug'
-})
+const isDebug = _.some(process.argv, arg => arg === '--debug')
 if (isDebug) {
   console.log('server.js called!  running in debug mode')
 }
@@ -256,6 +254,7 @@ const addOrRemoveDeltaToOrFromWiki = async ({
   hiddenParams.deltas = _.uniqBy(hiddenParams.deltas, 'dc')
   hiddenParams.deltas = _.sortBy(hiddenParams.deltas, ['uu'])
   const flairCount = hiddenParams.deltas.length
+  // eslint-disable-next-line
   let newContent = `[​](HTTP://DB3PARAMSSTART\n${JSON.stringify(hiddenParams, null, 2)}\nDB3PARAMSEND)\r\n/u/${user} has received ${flairCount} delta${flairCount === 1 ? '' : 's'} for the following comments:\r\n\r\n| Date | Submission | Delta Comment | Awarded By |\r\n| --- | :-: | --- | --- |\r\n`
   _.forEachRight(hiddenParams.deltas, col => {
     const { b, dc, t, ab, uu } = col
@@ -390,11 +389,14 @@ const verifyThenAward = async (comment) => {
         }
       )
       let text = i18n[locale].awardDelta
-      text = text.replace(/USERNAME/g, parentThing.author).replace(/DELTAS/g, flairCount).replace(/SUBREDDIT/g, subreddit)
+      text = text.replace(/USERNAME/g, parentThing.author)
+        .replace(/DELTAS/g, flairCount)
+        .replace(/SUBREDDIT/g, subreddit)
       if (query.text.length) query.text += '\n\n'
       query.text += text
       await updateFlair({ name: parentThing.author, flairCount })
     }
+    // eslint-disable-next-line
     query.text += `${i18n[locale].global}\n[​](HTTP://DB3PARAMSSTART\n${JSON.stringify(hiddenParams, null, 2)}\nDB3PARAMSEND)`
     const send = await reddit.query({ URL: `/api/comment?${stringify(query)}`, method: 'POST' })
     if (send.error) throw Error(send.error)
@@ -717,13 +719,14 @@ const entry = async () => {
   }
   try {
     let deltaBoardsThreeCredentials
+    /* eslint-disable import/no-unresolved */
     try {
       deltaBoardsThreeCredentials = require('./delta-boards-three-credentials')
     } catch (err) {
       console.log('Missing credentials for delta-boards-three! Using base creds as fallback!'.red)
       try {
         deltaBoardsThreeCredentials = require('./credentials')
-      } catch (err) {
+      } catch (secondErr) {
         console.log(
           'Please contact the author for credentials or create your own credentials json!'.red
         )
@@ -736,10 +739,11 @@ const entry = async () => {
         }`.red)
       }
     }
+    /* eslint-enable import/no-unresolved */
     const deltaBoardsThree = new DeltaBoardsThree({
       credentials: deltaBoardsThreeCredentials,
       version: packageJson.version,
-      flags
+      flags,
     })
     deltaBoardsThree.initialStart()
   } catch (err) {


### PR DESCRIPTION
Given your comments in #51 it probably makes sense to put eslint into the documentation somewhere, and provide an alias for it, like so.  Less likely to trip folks up in that case.

Along the same lines, I fixed all the errors I saw (to be fair, I did introduce some of these in the first place)