### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "6"

--- a/server.js
+++ b/server.js
@@ -39,7 +39,9 @@ let state
 let lastParsedCommentIDs
 let lastParsedCommentID
 try {
+  /* eslint-disable import/no-unresolved */
   state = require('./state.json')
+  /* eslint-enable import/no-unresolved */
 
   lastParsedCommentIDs = state.lastParsedCommentIDs
   lastParsedCommentID = lastParsedCommentIDs[0]
@@ -51,7 +53,9 @@ try {
 }
 let credentials
 try {
+  /* eslint-disable import/no-unresolved */
   credentials = require('./credentials')
+  /* eslint-enable import/no-unresolved */
 } catch (err) {
   console.log('Missing credentials!'.red)
   console.log('Please contact the author for credentials or create your own credentials json!'.red)
@@ -149,7 +153,7 @@ const addOrRemoveDeltaToOrFromWiki = async ({
       }
       if (content) {
         const links = _.uniq(
-            content.match(new RegExp(`/r/${subreddit}/comments/[^()[\\]]+\?context=2`, 'g'))
+            content.match(new RegExp(`/r/${subreddit}/comments/[^()[\\]]+?context=2`, 'g'))
         )
         const arrayFullnames = (
           _(links)


### PR DESCRIPTION
Per my comments in #52.  Someone with access to the repo settings would need to enable the webhook (see https://travis-ci.org/getting_started ), but after that every push should be covered.  You can login to travis with your github, and it's free for OSS projects, so I figure it fits pretty well overall.  By default, travis runs `npm test` for node projects ( https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Default-Test-Script ) which fits us well, at least running eslint on pull requests.  Should be trivial after that to link to the status icon on the readme, etc, I figure.  Then step two someone can figure out uploading artifacts ( https://docs.travis-ci.com/user/uploading-artifacts/ ) but running eslint on requests alone is probably worth it already.