### PR TITLE
fix(scripts): change supervisor command format

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The third rewrite of delta bot",
   "main": "entry.js",
   "scripts": {
-    "start": "supervisor -w ./lib/server.js ./lib/server.js",
+    "start": "supervisor -w ./lib/server.js -- ./lib/server.js",
     "start-debug": "node ./entry.js --debug",
     "test": "eslint ./RedditAPIDriver ./delta-boards-three server.js",
     "build": "browserify --node --no-bundle-external ./entry.js -t babelify -o ./lib/server.js",


### PR DESCRIPTION
The start script used to run supervisor with 'supervisor -w ./lib/server.js ./lib/server.js'. This caused issues when trying to call DeltaBot with command line arguments. supervisor would interpret the arguments as arguments for itself instead of arguments for the node package. As a result, DeltaBot would not run when called with arguments and would simply print supervisor's help message.

By changing the start script to 'supervisor -w ./lib/server.js -- ./lib/server.js' supervisor correctly interprets arguments passed to 'npm start' as arguments for the node package.