### PR TITLE
feat(argv): add --bypass-op-check cmd line arg

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ import parseHiddenParams from './parse-hidden-params'
 import getWikiContent from './get-wiki-content'
 
 const isDebug = _.some(process.argv, arg => arg === '--debug')
+const bypassOPCheck = _.some(process.argv, arg => arg === '--bypass-op-check')
 if (isDebug) {
   console.log('server.js called!  running in debug mode')
 }
@@ -354,7 +355,7 @@ const verifyThenAward = async (comment) => {
         (
             !parentID.match(/^t1_/g) ||
             parentThing.author === listing.author
-        ) && author.toLowerCase() !== 'mystk'
+        ) && bypassOPCheck === false
     ) {
       console.log(
         `BAILOUT parent author, ${parentThing.author} is listing author, ${listing.author}`


### PR DESCRIPTION
If someone attempts to award a delta to OP (the poster of the thread) the bot will not accept their delta. This commit adds a command line argument '--bypass-op-check' to allow deltas to be awarded to OP. Mainly used for testing, this will be useful as it saves testers time, allowing them to use a command line argument instead of changing the code to skip over this test.