### PR TITLE
fix(deltaboard): ensure underscores in deltaboard are escaped, to avoid bold/italics

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,12 @@
   "presets": [
     "es2015",
     "stage-3"
-  ]
+  ],
+  "env": {
+    "testing" : {
+      "plugins": [
+        "transform-runtime"
+      ]
+    }
+  }
 }

--- a/delta-boards-three/index.js
+++ b/delta-boards-three/index.js
@@ -4,6 +4,10 @@ import Api from './../RedditAPIDriver'
 import parseHiddenParams from './../parse-hidden-params'
 import getWikiContent from './../get-wiki-content'
 
+export function escapeUsername(username) {
+  return username.replace(/_/g, '\\_')
+}
+
 class DeltaBoardsThree {
   constructor({ credentials, version, flags }) {
     this.credentials = credentials // this is used to log into the Reddit API
@@ -212,8 +216,8 @@ class DeltaBoardsThree {
           return (
             `| ${rank} | ${
               rank === 1 ?
-                `**[${username}](/r/${subreddit}/wiki/user/${username})**` :
-                `[${username}](/r/${subreddit}/wiki/user/${username})`
+                `**[${escapeUsername(username)}](/r/${subreddit}/wiki/user/${username})**` :
+                `[${escapeUsername(username)}](/r/${subreddit}/wiki/user/${username})`
             } | ${deltaCount} |`
           )
         })

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "start": "supervisor -w ./lib/server.js -- ./lib/server.js",
     "start-debug": "node ./entry.js --debug",
-    "test": "concurrently \"npm run build\" \"eslint ./RedditAPIDriver ./delta-boards-three server.js\"",
+    "test": "concurrently \"npm run build\" \"eslint ./RedditAPIDriver ./delta-boards-three server.js\" \"nodeunit tests/main.js\"",
     "build": "browserify --node --no-bundle-external ./entry.js -t babelify -o ./lib/server.js",
-    "watch": "watchify --node --no-bundle-external ./entry.js -t babelify -o ./lib/server.js"
+    "watch": "watchify --node --no-bundle-external ./entry.js -t babelify -o ./lib/server.js",
+    "nodeunit": "nodeunit"
   },
   "repository": {
     "type": "git",
@@ -22,13 +23,16 @@
   "homepage": "https://github.com/MystK/delta-bot-three#readme",
   "devDependencies": {
     "babel-eslint": "^6.1.2",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-polyfill": "^6.16.0",
+    "babel-register": "^6.18.0",
     "babelify": "^7.3.0",
     "browserify": "^13.1.0",
     "concurrently": "^3.1.0",
     "eslint": "^3.4.0",
     "eslint-config-airbnb-base": "^5.0.3",
     "eslint-plugin-import": "^1.14.0",
+    "nodeunit": "^0.10.2",
     "watchify": "^3.7.0"
   },
   "dependencies": {

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,0 +1,4 @@
+process.env.BABEL_ENV = 'testing';
+require('babel-register');
+
+exports.users = require('./users.js');

--- a/tests/users.js
+++ b/tests/users.js
@@ -1,0 +1,6 @@
+import { escapeUsername } from '../delta-boards-three/index.js'
+
+exports.testEscaping = (test) => {
+    test.strictEqual(escapeUsername('__UsName__'), '\\_\\_UsName\\_\\_');
+    test.done();
+};


### PR DESCRIPTION
Meant to address #79.  Do note: this is completely untested in terms of running the bot.  I can't think of any reason it would fail, but that doesn't mean there isn't one.  Notably, I'm not really sure how the sidebar formatting works - if there's anything special there - or if there's legal reddit usernames like `\_somename_/` which this might spoil.

All changes outside of index.js - notably re-added devDependencies - are for a testing setup.  I wouldn't expect you to run tests on the server, so I think this would be OK?  

Either way, open for comments and complaints in terms of all these changes.  Simple enough code change, as things go, so wanted to stub out a bit of test infrastructure while I was at any change.

EDIT: would I need to update the yarn lock?  I haven't used yarn yet, still npm at the moment.