### PR TITLE
Double delta comment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -590,7 +590,7 @@ export const verifyThenAward = async (comment) => {
   } = comment
 
   // check if DeltaBot has already replied to this comment
-  const commentURL = linkURL.replace('https://www.reddit.com', '') + id + '.json'
+  const commentURL = `${linkURL}${id}.json`.replace('https://www.reddit.com', '')
   const response = await reddit.query(commentURL, true)
   const replies = _.get(response, '[1].data.children[0].data.replies')
   const dbReplied = getDeltaBotReply(botUsername, replies)
@@ -941,7 +941,8 @@ const checkMessagesforDeltas = async () => {
                 .replace(/blockquote&gt;[^]*?\/blockquote&gt;/, '')
                 .replace(/pre&gt;[^]*?\/pre&gt;/, '')
           )
-          if (!!removedBodyHTML.match(/&amp;#8710;|&#8710;|∆|Δ/) || !!removedBodyHTML.match(/!delta/i)) {
+          if (!!removedBodyHTML.match(/&amp;#8710;|&#8710;|∆|Δ/) ||
+            !!removedBodyHTML.match(/!delta/i)) {
             await verifyThenAward(comment)
           }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -906,7 +906,6 @@ const checkMessagesforDeltas = async () => {
           const commentLink = comments.commentLinks[i]
           const response = await reddit.query(`${commentLink}`)
           const {
-            replies,
             link_id,
             author,
             body,
@@ -940,22 +939,14 @@ const checkMessagesforDeltas = async () => {
             created_utc,
             created,
           }
-          const dbReplied = _.reduce(_.get(replies, 'data.children'), (result, reply) => {
-            if (result) return result
-            return _.get(reply, 'data.author') === botUsername
-          }, false)
           const removedBodyHTML = (
               body_html
                 .replace(/blockquote&gt;[^]*?\/blockquote&gt;/, '')
                 .replace(/pre&gt;[^]*?\/pre&gt;/, '')
           )
-          if (
-              !dbReplied &&
-              (
-                  !!removedBodyHTML.match(/&amp;#8710;|&#8710;|∆|Δ/) ||
-                  !!removedBodyHTML.match(/!delta/i)
-              )
-          ) await verifyThenAward(comment)
+          if (!!removedBodyHTML.match(/&amp;#8710;|&#8710;|∆|Δ/) || !!removedBodyHTML.match(/!delta/i)) {
+            await verifyThenAward(comment)
+          }
         }
       } catch (err) {
         console.error(err)

--- a/src/index.js
+++ b/src/index.js
@@ -593,10 +593,7 @@ export const verifyThenAward = async (comment) => {
   const commentURL = linkURL.replace('https://www.reddit.com', '') + id + '.json'
   const response = await reddit.query(commentURL, true)
   const replies = _.get(response, '[1].data.children[0].data.replies')
-  const dbReplied = _.reduce(_.get(replies, 'data.children'), (result, reply) => {
-    if (result) return result
-    return _.get(reply, 'data.author') === botUsername
-  }, false)
+  const dbReplied = getDeltaBotReply(botUsername, replies)
 
   if (dbReplied) {
     return false

--- a/src/index.js
+++ b/src/index.js
@@ -588,6 +588,20 @@ export const verifyThenAward = async (comment) => {
     link_url: linkURL,
     id,
   } = comment
+
+  // check if DeltaBot has already replied to this comment
+  const commentURL = linkURL.replace('https://www.reddit.com', '') + id + '.json'
+  const response = await reddit.query(commentURL, true)
+  const replies = _.get(response, '[1].data.children[0].data.replies')
+  const dbReplied = _.reduce(_.get(replies, 'data.children'), (result, reply) => {
+    if (result) return result
+    return _.get(reply, 'data.author') === botUsername
+  }, false)
+
+  if (dbReplied) {
+    return false
+  }
+
   try {
     const {
       issueCount,


### PR DESCRIPTION
Fixes issue #28. There was a path in the code where it was not checked if DeltaBot already replied. It is now moved to the verifyAndAward function, which makes sure that all paths in the code must at least once check if DeltaBot has not already replied.

I also (first) took a look at the possibility of this being caused by some kind of race condition, but I could not find any problems. There is no way that DeltaBot would process the same comment again, so that can not cause it. Also, the retry system of API requests, although not perfect, seems to work as intended in my tests.