### PR TITLE
Weekly deltaboard bug

### DIFF
--- a/src/delta-boards-three.js
+++ b/src/delta-boards-three.js
@@ -38,8 +38,12 @@ class DeltaBoardsThree {
     const nowDayOfTheMonth = now.getDate()
     const nowMonth = now.getMonth()
     const nowYear = now.getFullYear()
-    const dateOfThisMonday = new Date(moment().set({ hour:0, minute:0, second:0, millisecond:0 }).isoWeekday(1).format())
-    const dateOfThisSunday = new Date(moment().set({ hour:23, minute:59, second:59, millisecond:0 }).isoWeekday(7).format())
+    const dateOfThisMonday = new Date(
+      moment().set({ hour: 0, minute: 0, second: 0, millisecond: 0 }).isoWeekday(1).format()
+    )
+    const dateOfThisSunday = new Date(
+      moment().set({ hour: 23, minute: 59, second: 59, millisecond: 0 }).isoWeekday(7).format()
+    )
     const dateOfFirstDayOfThisMonth = new Date(nowYear, nowMonth)
 
     // prep the object for the deltaBoards

--- a/src/delta-boards-three.js
+++ b/src/delta-boards-three.js
@@ -38,8 +38,8 @@ class DeltaBoardsThree {
     const nowDayOfTheMonth = now.getDate()
     const nowMonth = now.getMonth()
     const nowYear = now.getFullYear()
-    const dateOfThisMonday = new Date(moment().isoWeekday(1).format())
-    const dateOfThisSunday = new Date(moment().isoWeekday(7).format())
+    const dateOfThisMonday = new Date(moment().set({ hour:0, minute:0, second:0, millisecond:0 }).isoWeekday(1).format())
+    const dateOfThisSunday = new Date(moment().set({ hour:23, minute:59, second:59, millisecond:0 }).isoWeekday(7).format())
     const dateOfFirstDayOfThisMonth = new Date(nowYear, nowMonth)
 
     // prep the object for the deltaBoards


### PR DESCRIPTION
Fixes issue #107. Was a simple problem with the time used as start and end of the week. As the current time was used as the start of the week, no deltas were collected on Monday. Also the weekly deltas would shift based on the current time.