### PR TITLE
fix(deltaboards): Yearly deltaboard fixes

### DIFF
--- a/src/delta-boards-three.js
+++ b/src/delta-boards-three.js
@@ -51,7 +51,6 @@ class DeltaBoardsThree {
       daily: {}, // updates every minute
       weekly: {}, // updates every minute
       monthly: {}, // updates every hour
-      yearly: {}, // updates not yet
     }
 
     // set when to stop getting new comments by date
@@ -107,7 +106,6 @@ class DeltaBoardsThree {
         const childDate = new Date(createdUtc * 1000) // createdUtc is seconds. Date accepts ms
         const childDateDayOfTheMonth = childDate.getDate()
         const childMonth = childDate.getMonth()
-        const childYear = childDate.getFullYear()
         const newHiddenParams = parseHiddenParams(body)
 
         // continue only if hidden params
@@ -146,14 +144,6 @@ class DeltaBoardsThree {
                 const { monthly } = deltaBoards
                 addDelta({
                   board: monthly,
-                  username: parentUserName,
-                  time: createdUtc,
-                })
-              // add to yearly boards object
-              case (nowYear === childYear): // yearly boards
-                const { yearly } = deltaBoards
-                addDelta({
-                  board: yearly,
                   username: parentUserName,
                   time: createdUtc,
                 })
@@ -226,11 +216,7 @@ class DeltaBoardsThree {
       const oldHiddenParams = parseHiddenParams(deltaBoardsWikiContent)
 
       // copy the yearly hidden data
-      if (oldHiddenParams.yearly) {
-        newHiddenParams.yearly = oldHiddenParams.yearly
-      } else {
-        newHiddenParams.yearly = []
-      }
+      newHiddenParams.yearly = oldHiddenParams.yearly
 
       if (!oldHiddenParams.updateTimes) {
         newHiddenParams.updateTimes = {

--- a/src/delta-boards-year.js
+++ b/src/delta-boards-year.js
@@ -74,7 +74,7 @@ class DeltaBoardsYear {
       { URL: `/r/${subreddit}/api/wiki/edit`, method: 'POST', body: stringify(updateWikiQuery) }
     )
 
-    setTimeout(() => this.updateYearlyDeltaboard(), 3 * 3600 * 1000) // run again in 24 hours
+    setTimeout(() => this.updateYearlyDeltaboard(), 3 * 3600 * 1000) // run again in 3 hours
   }
   async getDeltasTotal(year, month = null) {
     const { api } = this

--- a/src/delta-boards-year.js
+++ b/src/delta-boards-year.js
@@ -1,5 +1,6 @@
 import { stringify } from 'query-string'
 import fs from 'fs'
+import _ from 'lodash'
 import promisify from 'promisify-node'
 import Api from './reddit-api-driver'
 import parseHiddenParams from './parse-hidden-params'
@@ -47,11 +48,11 @@ class DeltaBoardsYear {
       yearly.push({ username: user[0], deltaCount: user[1], newestDeltaTime: 0 })
     }
 
-    hiddenParams.yearly = yearly
-
-    if (hiddenParams.updateTimes) {
+    if (hiddenParams.updateTimes && !_.isEqual(hiddenParams.yearly, yearly)) {
       hiddenParams.updateTimes.yearly = getParsedDate()
     }
+
+    hiddenParams.yearly = yearly
 
     const hiddenSection = deltaBoardsWikiContent.match(/DB3PARAMSSTART[^]+DB3PARAMSEND/)[0].slice(
       'DB3PARAMSSTART'.length, -'DB3PARAMSEND'.length

--- a/src/delta-boards-year.js
+++ b/src/delta-boards-year.js
@@ -73,7 +73,7 @@ class DeltaBoardsYear {
       { URL: `/r/${subreddit}/api/wiki/edit`, method: 'POST', body: stringify(updateWikiQuery) }
     )
 
-    setTimeout(() => this.updateYearlyDeltaboard(), 24 * 3600 * 1000) // run again in 24 hours
+    setTimeout(() => this.updateYearlyDeltaboard(), 3 * 3600 * 1000) // run again in 24 hours
   }
   async getDeltasTotal(year, month = null) {
     const { api } = this
@@ -92,7 +92,8 @@ class DeltaBoardsYear {
       startOfPeriod = new Date(year, month - 1)
       end = new Date(year, month)
     }
-    const start = (startOfPeriod.getTime() / 1000) - (3600 * 24 * 7)
+    // subtract 6 months, as threads in last 6 months of last year can have deltas from this year
+    const start = (startOfPeriod.getTime() / 1000) - (3600 * 24 * 31 * 6)
 
     // crawl the specified time period for threads
     while (!finished) {


### PR DESCRIPTION
Fix for #152. Also made the yearly deltaboard update every 3 hours instead of daily, and made the yearly deltaboard consider all relevant threads from the previous year instead of only the last week.