### PR TITLE
feat(deltalog):  display parent comment/context of the awarded comment

### DIFF
--- a/i18n/index.json
+++ b/i18n/index.json
@@ -16,8 +16,8 @@
     "deltaLogTitle": "Deltas awarded in \"<%= title %>\"",
     "deltaLogContent": "Below is a list of the deltas awarded in [this post](<%= linkToPost %>).\n\nPlease note that a change of view [is not necessarily a reversal](https://www.reddit.com/r/changemyview/wiki/index#wiki_what_is_a_.27view.27.3F), and that OP awarding a delta doesn't mean the conversation has ended.\n\nFor a full explanation of the delta system, [see here](https://www.reddit.com/r/changemyview/wiki/deltasystem).\n\n-----\n\n# Deltas from OP /u/<%= opUsername %>\n\n[](HTTP://DB3-FROMOP)\n\n#Deltas from Other Users\n\n[](HTTP://DB3-FROMOTHER)",
     "deltaLogSticky": "/u/<%= username %> (OP) has awarded <%= opawarded %> in this post.\n\nAll comments that earned deltas (from OP or other users) are listed [**here**](<%= linkToPost %>), in /r/<%= deltaLogSubreddit %>.\n\nPlease note that a change of view [doesn't necessarily mean a reversal](https://www.reddit.com/r/changemyview/wiki/index#wiki_what_is_a_.27view.27.3F), or that the conversation has ended.\n\n^[Delta System Explained](https://www.reddit.com/r/changemyview/wiki/deltasystem) ^| ^[Deltaboards](https://www.reddit.com/r/changemyview/wiki/deltaboards)",
-    "deltaLogOPEntry": "* 1 delta from OP to /u/<%= awardedUsername %> for \"[<%= awardedText %>](<%= awardedLink %>)\"\n",
-    "deltaLogOtherEntry": "* 1 delta from /u/<%= awardingUsername %> to /u/<%= awardedUsername %> for \"[<%= awardedText %>](<%= awardedLink %>)\"\n",
+    "deltaLogOPEntry": "* 1 delta from OP to /u/<%= awardedUsername %> for \"[<%= awardedText %>](<%= awardedLink %>/?context=1)\"\n",
+    "deltaLogOtherEntry": "* 1 delta from /u/<%= awardingUsername %> to /u/<%= awardedUsername %> for \"[<%= awardedText %>](<%= awardedLink %>/?context=1)\"\n",
     "deltaLogNoneYet": "* None yet."
   }
 }


### PR DESCRIPTION
closes #183 

Tested [here](https://www.reddit.com/r/DeltaLogDB3Dev2/comments/60mb0i/deltas_awarded_in_hell_is_empty_and_all_the/) and [here](https://www.reddit.com/r/DeltaLogDB3Dev2/comments/62c4px/deltas_awarded_in_cmv_how_hard_it_is_that_we_have/)

I went with the less disruptive approach of baking `/?context=1` into the i18n.

This will add `/?context=1` to the awarded comment's link even when no such parent comment exists. In such a case, visiting the context-ed link [still works](https://www.reddit.com/r/changemyviewDB3Dev2/comments/62c4ky/cmv_how_hard_it_is_that_we_have_to_die/dfle08u/?context=1) without any ill effects.