### PR TITLE
fix(deltalog): xml-unescape the title of deltalog entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "node-fetch": "^1.6.3",
     "promisify-node": "^0.4.0",
     "query-string": "^4.3.2",
-    "snoowrap": "^1.12.0"
+    "snoowrap": "^1.12.0",
+    "unescape": "^0.2.0"
   },
   "jest": {
     "testEnvironment": "node"

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const path = require('path')
 // const bodyParser = require('koa-bodyparser')
 const Reddit = require('./reddit-api-driver')
 const DeltaBoards = require('./delta-boards')
+const unesc = require('unescape')
 const {
   checkCommentForDelta,
   generateDeltaBotCommentFromDeltaComment,
@@ -546,7 +547,7 @@ const findOrMakeDeltaLogPost = async (linkID, comment, parentThing) => {
   }
   // otherwise, create it & add the delta details to appropriate section
   const deltaLogSubject = deltaLogSubjectTemplate(
-      { title: comment.link_title.replace('&amp;', '&') }
+      { title: unesc(comment.link_title) }
   )
   const deltaLogCreationParams = {
     opUsername: comment.link_author,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3774,6 +3774,10 @@ undefsafe@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-0.0.3.tgz#ecca3a03e56b9af17385baac812ac83b994a962f"
 
+unescape@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/unescape/-/unescape-0.2.0.tgz#b78b9b60c86f1629df181bf53eee3bc8d6367ddf"
+
 update-notifier@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-0.5.0.tgz#07b5dc2066b3627ab3b4f530130f7eddda07a4cc"


### PR DESCRIPTION
closes #189

Tested [here](https://www.reddit.com/r/DeltaLogDB3Dev2/comments/64k2jy/deltas_awarded_in_cmv_your_sister_swims_out_to/)

I'm not too sure how modules are usually handled in NodeJS/Yarn, but the below is what I did; please tell me if any of these are wrong/defy convention.

- I have added a new dependency (unescape) to `package.json`
- I have checked in an updated `yarn.lock` (that was generated by issuing a bare `yarn`)
- I placed the require near the top of `index.js`
