### PR TITLE
feat(DeltaLog): aggregate deltas given for single comment by displaying awarders together

### DIFF
--- a/i18n/index.json
+++ b/i18n/index.json
@@ -1,5 +1,6 @@
 {
   "en-us": {
+    "andWithSpace": " and ",
     "awardDelta": "Confirmed: 1 delta awarded to /u/USERNAME ([DELTAS∆](/r/SUBREDDIT/wiki/user/USERNAME)).",
     "noAward": {
       "littleText": "The length of your comment suggests that you haven't properly explained how /u/PARENTUSERNAME changed your view (comment rule 4).\n\nDeltaBot is able to rescan edited comments. Please edit your comment with the required explanation.",
@@ -18,6 +19,7 @@
     "deltaLogSticky": "/u/<%= username %> (OP) has awarded <%= opawarded %> in this post.\n\nAll comments that earned deltas (from OP or other users) are listed [**here**](<%= linkToPost %>), in /r/<%= deltaLogSubreddit %>.\n\nPlease note that a change of view [doesn't necessarily mean a reversal](https://www.reddit.com/r/changemyview/wiki/index#wiki_what_is_a_.27view.27.3F), or that the conversation has ended.\n\n^[Delta System Explained](https://www.reddit.com/r/changemyview/wiki/deltasystem) ^| ^[Deltaboards](https://www.reddit.com/r/changemyview/wiki/deltaboards)",
     "deltaLogOPEntry": "* 1 delta from OP to /u/<%= awardedUsername %> for \"[<%= awardedText %>](<%= awardedLink %>/?context=1)\"\n",
     "deltaLogOtherEntry": "* 1 delta from /u/<%= awardingUsername %> to /u/<%= awardedUsername %> for \"[<%= awardedText %>](<%= awardedLink %>/?context=1)\"\n",
+    "deltaLogMultipleOthers": "* <%= count %> deltas from <%= users %> to /u/<%= awardedUsername %> for \"[<%= awardedText %>](<%= awardedLink %>/?context=1)\"\n",
     "deltaLogNoneYet": "* None yet."
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -242,6 +242,12 @@ const getNewCommentsBeforeCommentId = async ({
   return commentsToReturn
 }
 
+const parseCommentIdFromURL = (url) => {
+  const parts = url.split('/')
+  const idPart = _.last(parts)
+  return idPart
+}
+
 module.exports = {
   escapeUnderscore,
   getCommentAuthor,
@@ -257,4 +263,5 @@ module.exports = {
   checkIfValidCommentId,
   getLastValidCommentId,
   getNewCommentsBeforeCommentId,
+  parseCommentIdFromURL,
 }

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -35,6 +35,14 @@ describe('utilities', () => {
     expect(checkCommentForDelta(createMockCommentClass(
         'pre&gt;&amp;#8710;&#8710;∆Δ!delta!dElTa/pre&gt;'))).toBe(false)
   })
+
+  it('should be able to identify comment id from URL', () => {
+    const { parseCommentIdFromURL } = component
+    const url1 = 'https://www.reddit.com/r/db3_wyantb/comments/5ls1vf/deltacomments_in_cmv_can_we_get_a_stick_comment/di7f3wr'
+    const url2 = 'https://www.reddit.com/r/db3_wyantb/comments/5ls1vf/deltacomments_in_cmv_can_we_get_a_stick_comment/second'
+    expect(parseCommentIdFromURL(url1)).toBe('di7f3wr')
+    expect(parseCommentIdFromURL(url2)).toBe('second')
+  })
 })
 
 const paulRyanCMVPost = 'How about Paul Ryan\'s [anti-poverty plan](http://www.speaker.gov/press-release/republicans-unveil-better-way-fight-poverty)?  His goals and justifications there seem to be focused on measurable impact on quality of life (\"opportunities to succeed\", \"tailor benefits to people\'s needs\", \"way out of poverty\", \"help you stay on the path from dependence to independence\").\n\nHe wants to improve lives; whether his plan is the plan most likely to succeed is a different question, but that\'s clearly his motivation.\n\nOr look at his plan to [replace Obamacare:](http://www.speaker.gov/press-release/obamacare-failing-speaker-ryan-s-remarks-leadership-press-conference) “For people seeing their premiums skyrocket, Obamacare has already failed. For people suddenly stuck with only one plan to choose from—a monopoly—this law has failed them. For people with deductibles so high that they try to get by without going to the doctor, this law has failed them.  \n\n“There is a better way, and we have made it clear what we want to replace Obamacare with: a truly patient-centered system with more choices and lower costs. A system that gives you the control and the freedom that Obamacare has taken from you.\"\n\nThat\'s all about quality of life.  Again, he might be wrong or right on the details, but the plan is to improve quality of life.'


### PR DESCRIPTION
Mostly getting comfortable and setup with running the bot again, but...here we are!  An implementation for #128

Tested in https://www.reddit.com/r/db3_wyantb/comments/6e3yqs/deltas_awarded_in_deltacomments_in_cmv_can_we_get/ (note to snorrrrlax - yes, I basically disabled every validation test that the bot checks for before awarding deltas, since I'm just changing output format and not any of the rules or anything.  I'm aware the post looks completely ridiculous, hah.  But it's formatted as you were thinking now!)